### PR TITLE
Add Documentation link to KOTS admin console dashboard

### DIFF
--- a/manifests/k8s-app.yaml
+++ b/manifests/k8s-app.yaml
@@ -8,3 +8,5 @@ spec:
       - description: Open App
         # Embedded cluster uses direct HTTPS ingress, KOTS uses port-forward to http://harbor
         url: '{{repl if eq Distribution "embedded-cluster" }}https://{{repl ConfigOption "harbor_hostname" }}{{repl else }}http://harbor{{repl end }}'
+      - description: Documentation
+        url: https://goharbor.io/docs/

--- a/manifests/k8s-app.yaml
+++ b/manifests/k8s-app.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   descriptor:
     links:
-      - description: Open App
+      - description: Harbor Registry
         # Embedded cluster uses direct HTTPS ingress, KOTS uses port-forward to http://harbor
         url: '{{repl if eq Distribution "embedded-cluster" }}https://{{repl ConfigOption "harbor_hostname" }}{{repl else }}http://harbor{{repl end }}'
       - description: Documentation


### PR DESCRIPTION
## Summary
- Add Harbor documentation link to KOTS admin console dashboard
- Link labeled as "Documentation" points to official Harbor docs at https://goharbor.io/docs/
- Provides users easy access to Harbor documentation directly from the admin console

🤖 Generated with [Claude Code](https://claude.ai/code)