### PR TITLE
Add Replicated SDK as Harbor chart dependency

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -51,10 +51,16 @@ jobs:
           # Clean any existing packages
           rm -f manifests/*.tgz
 
+          # Update dependencies to fetch the Replicated SDK
+          helm dependency update harbor
+
           # Package the chart
           helm package harbor -d manifests -u
           echo "Packaged chart:"
           ls -la manifests/*.tgz
+
+          # Clean up downloaded dependencies
+          rm -rf harbor/charts/
 
       - name: Create test release
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Helm package artifacts
 manifests/*.tgz
+
+# Helm dependency charts
+harbor/charts/

--- a/harbor/Chart.yaml
+++ b/harbor/Chart.yaml
@@ -22,3 +22,7 @@ sources:
 - https://github.com/goharbor/harbor
 - https://github.com/goharbor/harbor-helm
 version: 1.17.2
+dependencies:
+- name: replicated
+  repository: oci://registry.replicated.com/library
+  version: 1.8.0

--- a/manifests/kots-app.yaml
+++ b/manifests/kots-app.yaml
@@ -27,6 +27,10 @@ spec:
     - statefulset/harbor-trivy
     - service/harbor-trivy
 
+    # Replicated SDK components
+    - deployment/replicated
+    - service/replicated
+
   ports:
     - serviceName: "harbor"
       servicePort: 8080

--- a/scripts/test-embedded-install.sh
+++ b/scripts/test-embedded-install.sh
@@ -106,23 +106,6 @@ $KUBECTL wait deployment/replicated --for=condition=available -n kotsadm --timeo
 echo "Waiting for Replicated SDK service to have endpoints..."
 $KUBECTL wait --for=jsonpath='{.subsets}' endpoints/replicated -n kotsadm --timeout=300s
 
-echo "Testing Replicated SDK integration - checking for customerEmail value..."
-# Get Harbor release values to check if SDK populated global.replicated.customerEmail
-RELEASE_NAME=$($KUBECTL get secrets -n kotsadm -l owner=helm -o json | jq -r '.items[] | select(.metadata.labels.name | startswith("harbor")) | .metadata.labels.name' | head -1)
-if [[ -n "$RELEASE_NAME" ]]; then
-    echo "Found Harbor release: $RELEASE_NAME"
-    echo "Retrieving Helm values to check for global.replicated.customerEmail..."
-    helm get values "$RELEASE_NAME" -n kotsadm --all | tee /tmp/harbor-values.yaml
-    echo ""
-    echo "Looking for global.replicated.customerEmail specifically:"
-    grep -A 10 "global:" /tmp/harbor-values.yaml | grep -A 5 "replicated:" || echo "⚠️  No global.replicated section found"
-    echo ""
-    echo "Full global section:"
-    grep -A 20 "global:" /tmp/harbor-values.yaml || echo "⚠️  No global section found"
-else
-    echo "⚠️  Could not find Harbor Helm release to check values"
-fi
-
 echo "All resources verified and ready!"
 
 # Verify NGINX Ingress Controller

--- a/scripts/test-embedded-install.sh
+++ b/scripts/test-embedded-install.sh
@@ -100,6 +100,12 @@ $KUBECTL wait --for=jsonpath='{.subsets}' endpoints/harbor-jobservice -n kotsadm
 echo "Waiting for Trivy service to have endpoints..."
 $KUBECTL wait --for=jsonpath='{.subsets}' endpoints/harbor-trivy -n kotsadm --timeout=300s
 
+echo "Waiting for Replicated SDK deployment to be available..."
+$KUBECTL wait deployment/replicated --for=condition=available -n kotsadm --timeout=300s
+
+echo "Waiting for Replicated SDK service to have endpoints..."
+$KUBECTL wait --for=jsonpath='{.subsets}' endpoints/replicated -n kotsadm --timeout=300s
+
 echo "All resources verified and ready!"
 
 # Verify NGINX Ingress Controller

--- a/scripts/test-kots-install.sh
+++ b/scripts/test-kots-install.sh
@@ -112,6 +112,23 @@ kubectl wait deployment/replicated --for=condition=available -n ${NAMESPACE} --t
 echo "Waiting for Replicated SDK service to have endpoints..."
 kubectl wait --for=jsonpath='{.subsets}' endpoints/replicated -n ${NAMESPACE} --timeout=300s
 
+echo "Testing Replicated SDK integration - checking for customerEmail value..."
+# Get Harbor release values to check if SDK populated global.replicated.customerEmail
+RELEASE_NAME=$(kubectl get secrets -n ${NAMESPACE} -l owner=helm -o json | jq -r '.items[] | select(.metadata.labels.name | startswith("harbor")) | .metadata.labels.name' | head -1)
+if [[ -n "$RELEASE_NAME" ]]; then
+    echo "Found Harbor release: $RELEASE_NAME"
+    echo "Retrieving Helm values to check for global.replicated.customerEmail..."
+    helm get values "$RELEASE_NAME" -n ${NAMESPACE} --all | tee /tmp/harbor-values.yaml
+    echo ""
+    echo "Looking for global.replicated.customerEmail specifically:"
+    grep -A 10 "global:" /tmp/harbor-values.yaml | grep -A 5 "replicated:" || echo "⚠️  No global.replicated section found"
+    echo ""
+    echo "Full global section:"
+    grep -A 20 "global:" /tmp/harbor-values.yaml || echo "⚠️  No global section found"
+else
+    echo "⚠️  Could not find Harbor Helm release to check values"
+fi
+
 echo "All resources verified and ready!"
 
 # Show final status

--- a/scripts/test-kots-install.sh
+++ b/scripts/test-kots-install.sh
@@ -106,6 +106,12 @@ kubectl wait --for=jsonpath='{.subsets}' endpoints/harbor-jobservice -n ${NAMESP
 echo "Waiting for Trivy service to have endpoints..."
 kubectl wait --for=jsonpath='{.subsets}' endpoints/harbor-trivy -n ${NAMESPACE} --timeout=300s
 
+echo "Waiting for Replicated SDK deployment to be available..."
+kubectl wait deployment/replicated --for=condition=available -n ${NAMESPACE} --timeout=300s
+
+echo "Waiting for Replicated SDK service to have endpoints..."
+kubectl wait --for=jsonpath='{.subsets}' endpoints/replicated -n ${NAMESPACE} --timeout=300s
+
 echo "All resources verified and ready!"
 
 # Show final status

--- a/scripts/test-kots-install.sh
+++ b/scripts/test-kots-install.sh
@@ -112,23 +112,6 @@ kubectl wait deployment/replicated --for=condition=available -n ${NAMESPACE} --t
 echo "Waiting for Replicated SDK service to have endpoints..."
 kubectl wait --for=jsonpath='{.subsets}' endpoints/replicated -n ${NAMESPACE} --timeout=300s
 
-echo "Testing Replicated SDK integration - checking for customerEmail value..."
-# Get Harbor release values to check if SDK populated global.replicated.customerEmail
-RELEASE_NAME=$(kubectl get secrets -n ${NAMESPACE} -l owner=helm -o json | jq -r '.items[] | select(.metadata.labels.name | startswith("harbor")) | .metadata.labels.name' | head -1)
-if [[ -n "$RELEASE_NAME" ]]; then
-    echo "Found Harbor release: $RELEASE_NAME"
-    echo "Retrieving Helm values to check for global.replicated.customerEmail..."
-    helm get values "$RELEASE_NAME" -n ${NAMESPACE} --all | tee /tmp/harbor-values.yaml
-    echo ""
-    echo "Looking for global.replicated.customerEmail specifically:"
-    grep -A 10 "global:" /tmp/harbor-values.yaml | grep -A 5 "replicated:" || echo "⚠️  No global.replicated section found"
-    echo ""
-    echo "Full global section:"
-    grep -A 20 "global:" /tmp/harbor-values.yaml || echo "⚠️  No global section found"
-else
-    echo "⚠️  Could not find Harbor Helm release to check values"
-fi
-
 echo "All resources verified and ready!"
 
 # Show final status


### PR DESCRIPTION
## Summary
- Add Replicated SDK v1.8.0 as a subchart dependency to Harbor
- Update CI packaging process to include `helm dependency update`
- Add SDK deployment and service to KOTS status informers for monitoring
- Verify SDK resources are healthy in both embedded cluster and KOTS test scenarios

## Changes Made
- **harbor/Chart.yaml**: Added SDK dependency (oci://registry.replicated.com/library/replicated:1.8.0)
- **.gitignore**: Added `harbor/charts/` to exclude downloaded dependencies (follows Helm best practices)
- **.github/workflows/pr-test.yml**: Updated packaging to fetch dependencies and clean up afterward
- **manifests/kots-app.yaml**: Added SDK deployment/service to status informers
- **scripts/test-*.sh**: Added verification that SDK deployment and service are healthy

## Test Plan
- [x] PR tests will verify SDK is properly downloaded and packaged
- [x] Embedded cluster test will verify SDK deployment is available and service has endpoints
- [x] KOTS test will verify SDK deployment is available and service has endpoints
- [x] KOTS admin console will monitor SDK status via status informers

The SDK provides telemetry, metrics collection, and license checking capabilities to Harbor deployments.

🤖 Generated with [Claude Code](https://claude.ai/code)