### PR TITLE
chore: Update Nginx v4.13.3

### DIFF
--- a/chart-overlays/ingress-nginx/values-overlay.yaml
+++ b/chart-overlays/ingress-nginx/values-overlay.yaml
@@ -1,6 +1,6 @@
 # Generated image overlay for ingress-nginx chart
-# Source: ingress-nginx v4.13.2
-# Generated: 2025-09-26 11:50:20
+# Source: ingress-nginx v4.13.3
+# Generated: 2025-10-01 09:20:19
 #
 # No image transformations needed
 

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,9 +1,9 @@
 annotations:
   artifacthub.io/changes: |
-    - Update Ingress-Nginx version controller-v1.13.2
+    - Update Ingress-Nginx version controller-v1.13.3
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 1.13.2
+appVersion: 1.13.3
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
   load balancer
 home: https://github.com/kubernetes/ingress-nginx
@@ -20,4 +20,4 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.13.2
+version: 4.13.3

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.13.2](https://img.shields.io/badge/Version-4.13.2-informational?style=flat-square) ![AppVersion: 1.13.2](https://img.shields.io/badge/AppVersion-1.13.2-informational?style=flat-square)
+![Version: 4.13.3](https://img.shields.io/badge/Version-4.13.3-informational?style=flat-square) ![AppVersion: 1.13.3](https://img.shields.io/badge/AppVersion-1.13.3-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -273,10 +273,10 @@ metadata:
 | controller.admissionWebhooks.namespaceSelector | object | `{}` |  |
 | controller.admissionWebhooks.objectSelector | object | `{}` |  |
 | controller.admissionWebhooks.patch.enabled | bool | `true` |  |
-| controller.admissionWebhooks.patch.image.digest | string | `"sha256:050a34002d5bb4966849c880c56c91f5320372564245733b33d4b3461b4dbd24"` |  |
+| controller.admissionWebhooks.patch.image.digest | string | `"sha256:3d671cf20a35cd94efc5dcd484970779eb21e7938c98fbc3673693b8a117cf39"` |  |
 | controller.admissionWebhooks.patch.image.image | string | `"ingress-nginx/kube-webhook-certgen"` |  |
 | controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
-| controller.admissionWebhooks.patch.image.tag | string | `"v1.6.2"` |  |
+| controller.admissionWebhooks.patch.image.tag | string | `"v1.6.3"` |  |
 | controller.admissionWebhooks.patch.labels | object | `{}` | Labels to be added to patch job resources |
 | controller.admissionWebhooks.patch.networkPolicy.enabled | bool | `false` | Enable 'networkPolicy' or not |
 | controller.admissionWebhooks.patch.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
@@ -345,8 +345,8 @@ metadata:
 | controller.hostname | object | `{}` | Optionally customize the pod hostname. |
 | controller.image.allowPrivilegeEscalation | bool | `false` |  |
 | controller.image.chroot | bool | `false` |  |
-| controller.image.digest | string | `"sha256:1f7eaeb01933e719c8a9f4acd8181e555e582330c7d50f24484fb64d2ba9b2ef"` |  |
-| controller.image.digestChroot | string | `"sha256:2beb2139c53d6bcb9c8b11d68b412a6a1aa1de3a7e6040695848b0ce997b2be8"` |  |
+| controller.image.digest | string | `"sha256:1b044f6dcac3afbb59e05d98463f1dec6f3d3fb99940bc12ca5d80270358e3bd"` |  |
+| controller.image.digestChroot | string | `"sha256:27de15aea4ec7639f7cec6ae96bff11ce57bb1171040351a0b0eedf66655d0dd"` |  |
 | controller.image.image | string | `"ingress-nginx/controller"` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.readOnlyRootFilesystem | bool | `false` |  |
@@ -354,7 +354,7 @@ metadata:
 | controller.image.runAsNonRoot | bool | `true` |  |
 | controller.image.runAsUser | int | `101` | This value must not be changed using the official image. uid=101(www-data) gid=82(www-data) groups=82(www-data) |
 | controller.image.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| controller.image.tag | string | `"v1.13.2"` |  |
+| controller.image.tag | string | `"v1.13.3"` |  |
 | controller.ingressClass | string | `"nginx"` | For backwards compatibility with ingress.class annotation, use ingressClass. Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation |
 | controller.ingressClassByName | bool | `false` | Process IngressClass per name (additionally as per spec.controller). |
 | controller.ingressClassResource | object | `{"aliases":[],"annotations":{},"controllerValue":"k8s.io/ingress-nginx","default":false,"enabled":true,"name":"nginx","parameters":{}}` | This section refers to the creation of the IngressClass resource. IngressClasses are immutable and cannot be changed after creation. We do not support namespaced IngressClasses, yet, so a ClusterRole and a ClusterRoleBinding is required. |

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.3.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.3.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.3
+
+* Update Ingress-Nginx version controller-v1.13.3
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.2...helm-chart-4.13.3

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -30,9 +30,9 @@ controller:
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
-    tag: "v1.13.2"
-    digest: sha256:1f7eaeb01933e719c8a9f4acd8181e555e582330c7d50f24484fb64d2ba9b2ef
-    digestChroot: sha256:2beb2139c53d6bcb9c8b11d68b412a6a1aa1de3a7e6040695848b0ce997b2be8
+    tag: "v1.13.3"
+    digest: sha256:1b044f6dcac3afbb59e05d98463f1dec6f3d3fb99940bc12ca5d80270358e3bd
+    digestChroot: sha256:27de15aea4ec7639f7cec6ae96bff11ce57bb1171040351a0b0eedf66655d0dd
     pullPolicy: IfNotPresent
     runAsNonRoot: true
     # -- This value must not be changed using the official image.
@@ -820,8 +820,8 @@ controller:
         ## for backwards compatibility consider setting the full image url via the repository value below
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
-        tag: v1.6.2
-        digest: sha256:050a34002d5bb4966849c880c56c91f5320372564245733b33d4b3461b4dbd24
+        tag: v1.6.3
+        digest: sha256:3d671cf20a35cd94efc5dcd484970779eb21e7938c98fbc3673693b8a117cf39
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job
       ##

--- a/manifests/ingress-nginx.yaml
+++ b/manifests/ingress-nginx.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   chart:
     name: ingress-nginx
-    chartVersion: "4.13.2"
+    chartVersion: "4.13.3"
   releaseName: ingress-nginx
   weight: -20
   exclude: 'repl{{ ne Distribution "embedded-cluster" }}'


### PR DESCRIPTION
## 🚀 Automated Chart Updates

This PR automatically updates Helm charts and dependencies to their latest versions.

### 📋 Summary
## 📋 Detailed Changes

### 🌐 Ingress-Nginx Chart Update
- Updated from v4.13.2 to v4.13.3
- See [upstream releases](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.13.3) for detailed changes


### 🔧 Customizations Applied
All customizations are preserved through overlay files:
- **Harbor**: Image repositories, Replicated SDK dependency, cert-manager ClusterIssuers
- **Ingress-Nginx**: Global image registry override
- **Cert-Manager**: Image repositories for airgapped proxy registry

### 🔍 Verification Checklist
- [ ] Review `Chart.yaml` changes for version and dependencies
- [ ] Check `values.yaml` for any breaking changes or new options
- [ ] Verify template compatibility with existing deployments
- [ ] Validate that overlay files are correctly applied
- [ ] Test deployment in staging environment
- [ ] Ensure Replicated integration still works correctly

### 📁 Files Modified
- Charts: `charts/harbor/`, `charts/ingress-nginx/`, `charts/cert-manager/`
- Manifests: `manifests/harbor.yaml`, `manifests/ingress-nginx.yaml`, `manifests/cert-manager.yaml`
- Overlays: Preserved in `chart-overlays/` directory

### 🤖 Automation Info
- Workflow: `update-charts.yml`
- Script: `scripts/update-charts.sh`
- Trigger: Scheduled daily check
- Overlay System: Ensures all customizations are maintained

---

_This PR was created automatically by the chart update workflow. Please review and test before merging._