### PR TITLE
chore: Bump Replicated SDK from 1.8.0 to 1.16.0

### DIFF
--- a/charts/harbor/Chart.yaml
+++ b/charts/harbor/Chart.yaml
@@ -24,4 +24,4 @@ version: 1.18.0
 dependencies:
   - name: replicated
     repository: oci://registry.replicated.com/library
-    version: "1.8.0"
+    version: "1.16.0"


### PR DESCRIPTION
## Summary
Updates the Replicated SDK dependency in the Harbor chart from 1.8.0 to 1.16.0.

## Changes
- Updated `charts/harbor/Chart.yaml` to use Replicated SDK 1.16.0

## Benefits
- Access to latest SDK features and improvements
- Bug fixes and performance enhancements from SDK updates

## Test plan
- [x] Created release 1.0.1 with SDK 1.16.0 on Dev channel
- [ ] Verify deployment works correctly with new SDK version

🤖 Generated with [Claude Code](https://claude.com/claude-code)