### PR TITLE
feat: Add --wait-for-jobs flag to Helm chart installations

### DIFF
--- a/manifests/cert-manager.yaml
+++ b/manifests/cert-manager.yaml
@@ -11,6 +11,7 @@ spec:
   exclude: 'repl{{ ne Distribution "embedded-cluster" }}'
   helmUpgradeFlags:
     - --wait
+    - --wait-for-jobs
     - --timeout
     - 5m
   values:

--- a/manifests/harbor.yaml
+++ b/manifests/harbor.yaml
@@ -10,6 +10,7 @@ spec:
   weight: 0
   helmUpgradeFlags:
     - --wait
+    - --wait-for-jobs
     - --timeout
     - 5m
   values:

--- a/manifests/ingress-nginx.yaml
+++ b/manifests/ingress-nginx.yaml
@@ -11,6 +11,7 @@ spec:
   exclude: 'repl{{ ne Distribution "embedded-cluster" }}'
   helmUpgradeFlags:
     - --wait
+    - --wait-for-jobs
     - --timeout
     - 5m
   values:


### PR DESCRIPTION
## Summary
- Add `--wait-for-jobs` flag to harbor, cert-manager, and ingress-nginx Helm charts
- Ensures Helm installation doesn't finish until all jobs complete successfully

## What changed
The `helmUpgradeFlags` section now includes `--wait-for-jobs` in addition to `--wait`, ensuring that:
- Initialization jobs complete successfully
- Database migrations finish before the app is considered ready
- Setup tasks are fully done before marking installation complete

## Test plan
- [ ] Deploy to test cluster and verify jobs complete before installation finishes
- [ ] Verify Harbor initialization jobs complete successfully
- [ ] Verify cert-manager startup API check job completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)